### PR TITLE
fix: remove unnecessary replacement on alias resource update

### DIFF
--- a/internal/opnsense/firewall/alias/alias_resource.go
+++ b/internal/opnsense/firewall/alias/alias_resource.go
@@ -102,9 +102,6 @@ func (r *aliasResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the alias",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"type": schema.StringAttribute{
 				Required: true,

--- a/internal/opnsense/firewall/alias/alias_resource_test.go
+++ b/internal/opnsense/firewall/alias/alias_resource_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -71,35 +70,6 @@ func TestAccAliasResource_host(t *testing.T) {
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interfaces"), knownvalue.Null()),
 				},
 			},
-			// Update name testing (should trigger recreate)
-			{
-				Config: acctest.ProviderConfig + testAccAliasHostResourceModifiedNameConfig,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("opnsense_firewall_alias.test_acc_resource_host", plancheck.ResourceActionDestroyBeforeCreate),
-					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(false)),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource2")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("host")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("counters"), knownvalue.Bool(false)),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("updatefreq"), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"days":  knownvalue.Int32Exact(0),
-						"hours": knownvalue.Float64Exact(0),
-					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("description"), knownvalue.StringExact("[Updated] host alias for terraform resource testing")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"ipv4": knownvalue.Bool(false),
-						"ipv6": knownvalue.Bool(false),
-					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{
-						knownvalue.StringExact("1.1.1.1"),
-						knownvalue.StringExact("2.2.2.2"),
-					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interfaces"), knownvalue.Null()),
-				},
-			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})
@@ -124,21 +94,6 @@ const testAccAliasHostResourceModifiedConfig = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		enabled = false
 		name = "test_acc_alias_host_resource"
-		type = "host"
-		counters = false
-		description = "[Updated] host alias for terraform resource testing"
-		content = [
-			"1.1.1.1",
-			"2.2.2.2"
-		]
-	}
-`
-
-// testAccAliasHostResourceConfig defines an alias resource of type `host`
-const testAccAliasHostResourceModifiedNameConfig = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
-		enabled = false
-		name = "test_acc_alias_host_resource2"
 		type = "host"
 		counters = false
 		description = "[Updated] host alias for terraform resource testing"


### PR DESCRIPTION
Remove plan modifier for alias resource name. This allows the alias resource to be modified in place instead of being replaced unnecessarily.

Resolves #3 