### PR TITLE
test: remove unnecesary datasource output blocks

### DIFF
--- a/internal/opnsense/firewall/alias/alias_data_source_test.go
+++ b/internal/opnsense/firewall/alias/alias_data_source_test.go
@@ -78,10 +78,6 @@ const testAccAliasHostDataSourceIdConfig = `
 	data "opnsense_firewall_alias" "test_acc_data_source_host" {
 		id = opnsense_firewall_alias.test_acc_data_source_host.id
 	}
-
-	output "test_acc_alias_host" {
-		value = data.opnsense_firewall_alias.test_acc_data_source_host
-	}
 `
 
 // testAccAliasHostDataSourceNameConfig creates an alias resource and imports it as a data source via its name.
@@ -99,9 +95,5 @@ const testAccAliasHostDataSourceNameConfig = `
 
 	data "opnsense_firewall_alias" "test_acc_data_source_host" {
 		name = opnsense_firewall_alias.test_acc_data_source_host.name
-	}
-
-	output "test_acc_alias_host" {
-		value = data.opnsense_firewall_alias.test_acc_data_source_host
 	}
 `

--- a/internal/opnsense/firewall/category/category_data_source_test.go
+++ b/internal/opnsense/firewall/category/category_data_source_test.go
@@ -49,10 +49,6 @@ const testAccCategoryIdDataSourceConfig = `
 	data "opnsense_firewall_category" "test_acc_data_source_id" {
 		id = opnsense_firewall_category.test_acc_resource.id
 	}
-
-	output "test_acc_alias_host_id" {
-		value = data.opnsense_firewall_category.test_acc_data_source_id
-	}
 `
 
 // testAccCategoryNameDataSourceConfig creates a category before importing it as a data source by its name.
@@ -65,9 +61,5 @@ const testAccCategoryNameDataSourceConfig = `
 
 	data "opnsense_firewall_category" "test_acc_data_source_name" {
 		name = opnsense_firewall_category.test_acc_resource.name
-	}
-
-	output "test_acc_alias_host_name" {
-		value = data.opnsense_firewall_category.test_acc_data_source_name
 	}
 `


### PR DESCRIPTION
Remove unnecessary output blocks in various datasource test cases