### PR TITLE
test: remove unnecessary provider configurations

### DIFF
--- a/internal/opnsense/firewall/alias/alias_data_source_test.go
+++ b/internal/opnsense/firewall/alias/alias_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing (via id)
 			{
-				Config: acctest.ProviderConfig + testAccAliasHostDataSourceIdConfig,
+				Config: testAccAliasHostDataSourceIdConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_data_source")),
@@ -39,7 +39,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 			},
 			// Read testing (via name)
 			{
-				Config: acctest.ProviderConfig + testAccAliasHostDataSourceNameConfig,
+				Config: testAccAliasHostDataSourceNameConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_data_source")),

--- a/internal/opnsense/firewall/alias/alias_resource_test.go
+++ b/internal/opnsense/firewall/alias/alias_resource_test.go
@@ -48,7 +48,7 @@ func TestAccAliasResource_host(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: acctest.ProviderConfig + testAccAliasHostResourceModifiedConfig,
+				Config: testAccAliasHostResourceModifiedConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),

--- a/internal/opnsense/firewall/alias/geoip_data_source_test.go
+++ b/internal/opnsense/firewall/alias/geoip_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccGeoIpDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: acctest.ProviderConfig + testAccGeoIpDataSourceConfig,
+				Config: testAccGeoIpDataSourceConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias_geoip.test_acc_data_source", tfjsonpath.New("address_count"), knownvalue.Int64Exact(951473)),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias_geoip.test_acc_data_source", tfjsonpath.New("address_sources"), knownvalue.ObjectExact(map[string]knownvalue.Check{

--- a/internal/opnsense/firewall/category/category_data_source_test.go
+++ b/internal/opnsense/firewall/category/category_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccCategoryDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing (via id)
 			{
-				Config: acctest.ProviderConfig + testAccCategoryIdDataSourceConfig,
+				Config: testAccCategoryIdDataSourceConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_category.test_acc_data_source_id", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_category_resource")),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_category.test_acc_data_source_id", tfjsonpath.New("auto"), knownvalue.Bool(true)),
@@ -27,7 +27,7 @@ func TestAccCategoryDataSource(t *testing.T) {
 			},
 			// Read testing (via name)
 			{
-				Config: acctest.ProviderConfig + testAccCategoryNameDataSourceConfig,
+				Config: testAccCategoryNameDataSourceConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_category.test_acc_data_source_name", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_category_resource")),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_category.test_acc_data_source_name", tfjsonpath.New("auto"), knownvalue.Bool(true)),

--- a/internal/opnsense/firewall/category/category_resource_test.go
+++ b/internal/opnsense/firewall/category/category_resource_test.go
@@ -37,7 +37,7 @@ func TestAccCategoryResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: acctest.ProviderConfig + testAccCategoryResourceModifiedConfig,
+				Config: testAccCategoryResourceModifiedConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("opnsense_firewall_category.test_acc_resource", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_category_resource")),
 					statecheck.ExpectKnownValue("opnsense_firewall_category.test_acc_resource", tfjsonpath.New("auto"), knownvalue.Bool(false)),


### PR DESCRIPTION
Remove unnecessary provider configuration in various test cases. 

The provider configuration is already imported using the ProtoV6ProviderFactories field when defining the test cases.