### PR TITLE
fix(alias): dynipv6 interface should be single value instead of list

### DIFF
--- a/internal/opnsense/firewall/alias/alias_data_source.go
+++ b/internal/opnsense/firewall/alias/alias_data_source.go
@@ -128,10 +128,9 @@ func (d *aliasDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				ElementType: types.StringType,
 				Description: "The content of the alias",
 			},
-			"interface": schema.ListAttribute{
+			"interface": schema.StringAttribute{
 				Computed:    true,
 				Description: "[Only for `dynipv6` type] The interface for the v6 dynamic IP.",
-				ElementType: types.StringType,
 			},
 		},
 	}

--- a/internal/opnsense/firewall/alias/alias_data_source.go
+++ b/internal/opnsense/firewall/alias/alias_data_source.go
@@ -46,7 +46,7 @@ type aliasDataSourceModel struct {
 	Proto       types.Object   `tfsdk:"proto"`
 	Categories  []types.String `tfsdk:"categories"`
 	Content     []types.String `tfsdk:"content"`
-	Interfaces  []types.String `tfsdk:"interfaces"`
+	Interface   types.String   `tfsdk:"interface"`
 }
 
 // Metadata returns the data source type name.
@@ -128,9 +128,9 @@ func (d *aliasDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				ElementType: types.StringType,
 				Description: "The content of the alias",
 			},
-			"interfaces": schema.ListAttribute{
+			"interface": schema.ListAttribute{
 				Computed:    true,
-				Description: "[Only for `dynipv6` type] The alias interfaces",
+				Description: "[Only for `dynipv6` type] The interface for the v6 dynamic IP.",
 				ElementType: types.StringType,
 			},
 		},
@@ -211,7 +211,7 @@ func (d *aliasDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		"proto":       alias.Proto,
 		"categories":  alias.Categories,
 		"content":     alias.Content,
-		"interface":   alias.Interfaces,
+		"interface":   alias.Interface,
 	})
 
 	data.Name = types.StringValue(alias.Name)
@@ -247,7 +247,7 @@ func (d *aliasDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	data.Categories = utils.StringListGoToTerraform(alias.Categories)
 	data.Content = utils.StringListGoToTerraform(alias.Content)
-	data.Interfaces = utils.StringListGoToTerraform(alias.Interfaces)
+	data.Interface = types.StringValue(alias.Interface)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/opnsense/firewall/alias/alias_data_source_test.go
+++ b/internal/opnsense/firewall/alias/alias_data_source_test.go
@@ -34,7 +34,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 						"ipv6": knownvalue.Bool(false),
 					})),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("1.1.1.1")})),
-					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("interfaces"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
 				},
 			},
 			// Read testing (via name)
@@ -55,7 +55,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 						"ipv6": knownvalue.Bool(false),
 					})),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("1.1.1.1")})),
-					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("interfaces"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
 				},
 			},
 		},

--- a/internal/opnsense/firewall/alias/alias_data_source_test.go
+++ b/internal/opnsense/firewall/alias/alias_data_source_test.go
@@ -89,6 +89,39 @@ func TestAccAliasDataSource_dynipv6(t *testing.T) {
 	})
 }
 
+func TestAccAliasDataSource_asn(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing (via id)
+			{
+				Config: testAccAliasDataSourceConfig_asn_id,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_data_source")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"ipv4": knownvalue.Bool(true),
+						"ipv6": knownvalue.Bool(true),
+					})),
+				},
+			},
+			// Read testing (via name)
+			{
+				Config: testAccAliasDataSourceConfig_asn_name,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_data_source")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_asn", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"ipv4": knownvalue.Bool(true),
+						"ipv6": knownvalue.Bool(true),
+					})),
+				},
+			},
+		},
+	})
+}
+
 // testAccAliasDataSourceConfig_host_id creates an alias resource of type 'host' and imports it as a data source via its id.
 const testAccAliasDataSourceConfig_host_id = `
 	resource "opnsense_firewall_alias" "test_acc_data_source_host" {
@@ -125,7 +158,7 @@ const testAccAliasDataSourceConfig_host_name = `
 	}
 `
 
-// testAccAliasDataSourceConfig_dynipv6_id creates an alias resource of type 'dynipv6host' and imports it as a data source via its id.
+// testAccAliasDataSourceConfig_dynipv6_id creates an alias resource of type 'dynipv6host' (tests interface) and imports it as a data source via its id .
 const testAccAliasDataSourceConfig_dynipv6_id = `
 	resource "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
 		name = "test_acc_alias_dyn_data_source"
@@ -138,7 +171,7 @@ const testAccAliasDataSourceConfig_dynipv6_id = `
 	}
 `
 
-// testAccAliasDataSourceConfig_dynipv6_name creates an alias resource of type 'dynipv6host' and imports it as a data source via its name.
+// testAccAliasDataSourceConfig_dynipv6_name creates an alias resource of type 'dynipv6host' (tests interface) and imports it as a data source via its name (tests proto).
 const testAccAliasDataSourceConfig_dynipv6_name = `
 	resource "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
 		name = "test_acc_alias_dyn_data_source"
@@ -148,5 +181,37 @@ const testAccAliasDataSourceConfig_dynipv6_name = `
 
 	data "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
 		name = opnsense_firewall_alias.test_acc_data_source_dynipv6.name
+	}
+`
+
+// testAccAliasDataSourceConfig_asn_id creates an alias resource of type 'asn' (tests proto) and imports it as a data source via its id.
+const testAccAliasDataSourceConfig_asn_id = `
+	resource "opnsense_firewall_alias" "test_acc_data_source_asn" {
+		name = "test_acc_alias_asn_data_source"
+		type = "asn"
+		proto = {
+			ipv4 = true
+			ipv6 = true
+		}
+	}
+
+	data "opnsense_firewall_alias" "test_acc_data_source_asn" {
+		id = opnsense_firewall_alias.test_acc_data_source_asn.id
+	}
+`
+
+// testAccAliasDataSourceConfig_asn_name creates an alias resource of type 'asn' (tests proto) and imports it as a data source via its name.
+const testAccAliasDataSourceConfig_asn_name = `
+	resource "opnsense_firewall_alias" "test_acc_data_source_asn" {
+		name = "test_acc_alias_asn_data_source"
+		type = "asn"
+		proto = {
+			ipv4 = true
+			ipv6 = true
+		}
+	}
+
+	data "opnsense_firewall_alias" "test_acc_data_source_asn" {
+		name = opnsense_firewall_alias.test_acc_data_source_asn.name
 	}
 `

--- a/internal/opnsense/firewall/alias/alias_data_source_test.go
+++ b/internal/opnsense/firewall/alias/alias_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing (via id)
 			{
-				Config: testAccAliasHostDataSourceIdConfig,
+				Config: testAccAliasDataSourceConfig_host_id,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_data_source")),
@@ -39,7 +39,7 @@ func TestAccAliasDataSource_host(t *testing.T) {
 			},
 			// Read testing (via name)
 			{
-				Config: testAccAliasHostDataSourceNameConfig,
+				Config: testAccAliasDataSourceConfig_host_name,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_data_source")),
@@ -62,8 +62,35 @@ func TestAccAliasDataSource_host(t *testing.T) {
 	})
 }
 
-// testAccAliasHostDataSourceIdConfig creates an alias resource and imports it as a data source via its id.
-const testAccAliasHostDataSourceIdConfig = `
+func TestAccAliasDataSource_dynipv6(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing (via id)
+			{
+				Config: testAccAliasDataSourceConfig_dynipv6_id,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dyn_data_source")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("interface"), knownvalue.StringExact("opt1")),
+				},
+			},
+			// Read testing (via name)
+			{
+				Config: testAccAliasDataSourceConfig_dynipv6_name,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dyn_data_source")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("data.opnsense_firewall_alias.test_acc_data_source_dynipv6", tfjsonpath.New("interface"), knownvalue.StringExact("opt1")),
+				},
+			},
+		},
+	})
+}
+
+// testAccAliasDataSourceConfig_host_id creates an alias resource of type 'host' and imports it as a data source via its id.
+const testAccAliasDataSourceConfig_host_id = `
 	resource "opnsense_firewall_alias" "test_acc_data_source_host" {
 		enabled = true
 		name = "test_acc_alias_host_data_source"
@@ -80,8 +107,8 @@ const testAccAliasHostDataSourceIdConfig = `
 	}
 `
 
-// testAccAliasHostDataSourceNameConfig creates an alias resource and imports it as a data source via its name.
-const testAccAliasHostDataSourceNameConfig = `
+// testAccAliasHostDataSourceNameConfig creates an alias resource of type 'host' and imports it as a data source via its name.
+const testAccAliasDataSourceConfig_host_name = `
 	resource "opnsense_firewall_alias" "test_acc_data_source_host" {
 		enabled = true
 		name = "test_acc_alias_host_data_source"
@@ -95,5 +122,31 @@ const testAccAliasHostDataSourceNameConfig = `
 
 	data "opnsense_firewall_alias" "test_acc_data_source_host" {
 		name = opnsense_firewall_alias.test_acc_data_source_host.name
+	}
+`
+
+// testAccAliasDataSourceConfig_dynipv6_id creates an alias resource of type 'dynipv6host' and imports it as a data source via its id.
+const testAccAliasDataSourceConfig_dynipv6_id = `
+	resource "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
+		name = "test_acc_alias_dyn_data_source"
+		type = "dynipv6host"
+		interface = "opt1"
+	}
+
+	data "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
+		id = opnsense_firewall_alias.test_acc_data_source_dynipv6.id
+	}
+`
+
+// testAccAliasDataSourceConfig_dynipv6_name creates an alias resource of type 'dynipv6host' and imports it as a data source via its name.
+const testAccAliasDataSourceConfig_dynipv6_name = `
+	resource "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
+		name = "test_acc_alias_dyn_data_source"
+		type = "dynipv6host"
+		interface = "opt1"
+	}
+
+	data "opnsense_firewall_alias" "test_acc_data_source_dynipv6" {
+		name = opnsense_firewall_alias.test_acc_data_source_dynipv6.name
 	}
 `

--- a/internal/opnsense/firewall/alias/alias_resource.go
+++ b/internal/opnsense/firewall/alias/alias_resource.go
@@ -58,7 +58,7 @@ type aliasResourceModel struct {
 	Proto       types.Object   `tfsdk:"proto"`
 	Categories  []types.String `tfsdk:"categories"`
 	Content     []types.String `tfsdk:"content"`
-	Interfaces  []types.String `tfsdk:"interfaces"`
+	Interface   types.String   `tfsdk:"interface"`
 }
 
 type updateFreqModel struct {
@@ -201,12 +201,11 @@ func (r *aliasResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description: "The content of the alias. Ensure that the content are in lexicographical order, else the provider will detect a change on every execution.",
 				Default:     listdefault.StaticValue(emptyList),
 			},
-			"interfaces": schema.ListAttribute{
+			"interfaces": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "[Only for `dynipv6` type] The alias interfaces. Ensure that the interfaces are in lexicographical order, else the provider will detect a change on every execution.",
-				ElementType: types.StringType,
-				Default:     listdefault.StaticValue(emptyList),
+				Description: "[Only for `dynipv6` type] The interface for the v6 dynamic IP.",
+				Default:     stringdefault.StaticString(""),
 			},
 		},
 	}
@@ -342,7 +341,7 @@ func (r *aliasResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	state.Categories = utils.StringListGoToTerraform(alias.Categories)
 	state.Content = utils.StringListGoToTerraform(alias.Content)
-	state.Interfaces = utils.StringListGoToTerraform(alias.Interfaces)
+	state.Interface = types.StringValue(alias.Interface)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/opnsense/firewall/alias/alias_resource.go
+++ b/internal/opnsense/firewall/alias/alias_resource.go
@@ -201,7 +201,7 @@ func (r *aliasResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description: "The content of the alias. Ensure that the content are in lexicographical order, else the provider will detect a change on every execution.",
 				Default:     listdefault.StaticValue(emptyList),
 			},
-			"interfaces": schema.StringAttribute{
+			"interface": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "[Only for `dynipv6` type] The interface for the v6 dynamic IP.",

--- a/internal/opnsense/firewall/alias/alias_resource_test.go
+++ b/internal/opnsense/firewall/alias/alias_resource_test.go
@@ -109,6 +109,48 @@ func TestAccAliasResource_dynipv6(t *testing.T) {
 	})
 }
 
+func TestAccAliasResource_asn(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAliasResourceConfig_asn,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"ipv4": knownvalue.Bool(true),
+						"ipv6": knownvalue.Bool(true),
+					})),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:            "opnsense_firewall_alias.test_acc_resource_host",
+				ImportState:             true,
+				ImportStateId:           "test_acc_alias_asn_resource",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+			// Update testing
+			{
+				Config: testAccAliasResourceConfig_asn_modified,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"ipv4": knownvalue.Bool(false),
+						"ipv6": knownvalue.Bool(false),
+					})),
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccAliasResource_defaults(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
@@ -177,7 +219,7 @@ const testAccAliasResourceConfig_host_modified = `
 	}
 `
 
-// testAccAliasResourceConfig_dynipv6 defines an alias resource of type `dynipv6host`.
+// testAccAliasResourceConfig_dynipv6 defines an alias resource of type `dynipv6host` tests interface).
 const testAccAliasResourceConfig_dynipv6 = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		name = "test_acc_alias_dynipv6_resource"
@@ -186,12 +228,36 @@ const testAccAliasResourceConfig_dynipv6 = `
 	}
 `
 
-// testAccAliasResourceConfig_dynipv6_modified defines a modified alias resource of type `dynipv6host`.
+// testAccAliasResourceConfig_dynipv6_modified defines a modified alias resource of type `dynipv6host` (tests interface).
 const testAccAliasResourceConfig_dynipv6_modified = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		name = "test_acc_alias_dynipv6_resource"
 		type = "dynipv6host"
 		interface = "lan"
+	}
+`
+
+// testAccAliasResourceConfig_asn defines an alias resource of type `asn` (tests proto).
+const testAccAliasResourceConfig_asn = `
+	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+		name = "test_acc_alias_asn_resource"
+		type = "asn"
+		proto = {
+			ipv4 = true
+			ipv6 = true
+		}
+	}
+`
+
+// testAccAliasResourceConfig_asn_modified defines a modified alias resource of type `asn` (tests proto).
+const testAccAliasResourceConfig_asn_modified = `
+	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+		name = "test_acc_alias_asn_resource"
+		type = "asn"
+		proto = {
+			ipv4 = false
+			ipv6 = false
+		}
 	}
 `
 

--- a/internal/opnsense/firewall/alias/alias_resource_test.go
+++ b/internal/opnsense/firewall/alias/alias_resource_test.go
@@ -17,7 +17,7 @@ func TestAccAliasResource_host(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAliasHostResourceConfig,
+				Config: testAccAliasResourceConfig_host,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),
@@ -33,7 +33,7 @@ func TestAccAliasResource_host(t *testing.T) {
 						"ipv6": knownvalue.Bool(false),
 					})),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("1.1.1.1")})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interfaces"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
 				},
 			},
 			// ImportState testing
@@ -46,7 +46,7 @@ func TestAccAliasResource_host(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccAliasHostResourceModifiedConfig,
+				Config: testAccAliasResourceConfig_host_modified,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),
@@ -65,7 +65,43 @@ func TestAccAliasResource_host(t *testing.T) {
 						knownvalue.StringExact("1.1.1.1"),
 						knownvalue.StringExact("2.2.2.2"),
 					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interfaces"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccAliasResource_dynipv6(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAliasResourceConfig_dynipv6,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("opt1")),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:            "opnsense_firewall_alias.test_acc_resource_host",
+				ImportState:             true,
+				ImportStateId:           "test_acc_alias_dynipv6_resource",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+			// Update testing
+			{
+				Config: testAccAliasResourceConfig_dynipv6_modified,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("lan")),
 				},
 			},
 			// Delete testing automatically occurs in TestCase
@@ -80,7 +116,7 @@ func TestAccAliasResource_defaults(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAliasHostResourceDefaultConfig,
+				Config: testAccAliasResourceConfig_default,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),
@@ -96,7 +132,7 @@ func TestAccAliasResource_defaults(t *testing.T) {
 						"ipv6": knownvalue.Bool(false),
 					})),
 					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interfaces"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
 				},
 			},
 			// ImportState testing
@@ -112,8 +148,8 @@ func TestAccAliasResource_defaults(t *testing.T) {
 	})
 }
 
-// testAccAliasHostResourceConfig defines an alias resource of type `host`.
-const testAccAliasHostResourceConfig = `
+// testAccAliasResourceConfig_host defines an alias resource of type `host`.
+const testAccAliasResourceConfig_host = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		enabled = true
 		name = "test_acc_alias_host_resource"
@@ -126,8 +162,8 @@ const testAccAliasHostResourceConfig = `
 	}
 `
 
-// testAccAliasHostResourceModifiedConfig defines a modified alias resource of type `host`.
-const testAccAliasHostResourceModifiedConfig = `
+// testAccAliasResourceConfig_host_modified defines a modified alias resource of type `host`.
+const testAccAliasResourceConfig_host_modified = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		enabled = false
 		name = "test_acc_alias_host_resource"
@@ -141,8 +177,26 @@ const testAccAliasHostResourceModifiedConfig = `
 	}
 `
 
-// testAccAliasHostResourceDefaultConfig defines an alias resource of type `host` with default values.
-const testAccAliasHostResourceDefaultConfig = `
+// testAccAliasResourceConfig_dynipv6 defines an alias resource of type `dynipv6host`.
+const testAccAliasResourceConfig_dynipv6 = `
+	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+		name = "test_acc_alias_dynipv6_resource"
+		type = "dynipv6host"
+		interface = "opt1"
+	}
+`
+
+// testAccAliasResourceConfig_dynipv6_modified defines a modified alias resource of type `dynipv6host`.
+const testAccAliasResourceConfig_dynipv6_modified = `
+	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+		name = "test_acc_alias_dynipv6_resource"
+		type = "dynipv6host"
+		interface = "lan"
+	}
+`
+
+// testAccAliasResourceConfig_default defines an alias resource of type `host` with default values.
+const testAccAliasResourceConfig_default = `
 	resource "opnsense_firewall_alias" "test_acc_resource_host" {
 		name = "test_acc_alias_host_resource"
 		type = "host"

--- a/internal/opnsense/firewall/alias/alias_resource_test.go
+++ b/internal/opnsense/firewall/alias/alias_resource_test.go
@@ -82,14 +82,14 @@ func TestAccAliasResource_dynipv6(t *testing.T) {
 			{
 				Config: testAccAliasResourceConfig_dynipv6,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("opt1")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("interface"), knownvalue.StringExact("opt1")),
 				},
 			},
 			// ImportState testing
 			{
-				ResourceName:            "opnsense_firewall_alias.test_acc_resource_host",
+				ResourceName:            "opnsense_firewall_alias.test_acc_resource_dynipv6",
 				ImportState:             true,
 				ImportStateId:           "test_acc_alias_dynipv6_resource",
 				ImportStateVerify:       true,
@@ -99,9 +99,9 @@ func TestAccAliasResource_dynipv6(t *testing.T) {
 			{
 				Config: testAccAliasResourceConfig_dynipv6_modified,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("lan")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_dynipv6_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("type"), knownvalue.StringExact("dynipv6host")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_dynipv6", tfjsonpath.New("interface"), knownvalue.StringExact("lan")),
 				},
 			},
 			// Delete testing automatically occurs in TestCase
@@ -118,9 +118,9 @@ func TestAccAliasResource_asn(t *testing.T) {
 			{
 				Config: testAccAliasResourceConfig_asn,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"ipv4": knownvalue.Bool(true),
 						"ipv6": knownvalue.Bool(true),
 					})),
@@ -128,7 +128,7 @@ func TestAccAliasResource_asn(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:            "opnsense_firewall_alias.test_acc_resource_host",
+				ResourceName:            "opnsense_firewall_alias.test_acc_resource_asn",
 				ImportState:             true,
 				ImportStateId:           "test_acc_alias_asn_resource",
 				ImportStateVerify:       true,
@@ -138,9 +138,9 @@ func TestAccAliasResource_asn(t *testing.T) {
 			{
 				Config: testAccAliasResourceConfig_asn_modified,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_asn_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("type"), knownvalue.StringExact("asn")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_asn", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"ipv4": knownvalue.Bool(false),
 						"ipv6": knownvalue.Bool(false),
 					})),
@@ -160,26 +160,26 @@ func TestAccAliasResource_defaults(t *testing.T) {
 			{
 				Config: testAccAliasResourceConfig_default,
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("type"), knownvalue.StringExact("host")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("counters"), knownvalue.Bool(false)),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("updatefreq"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("name"), knownvalue.StringExact("test_acc_alias_host_resource")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("type"), knownvalue.StringExact("host")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("counters"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("updatefreq"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"days":  knownvalue.Int32Exact(0),
 						"hours": knownvalue.Float64Exact(0),
 					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("description"), knownvalue.StringExact("")),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("description"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("proto"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"ipv4": knownvalue.Bool(false),
 						"ipv6": knownvalue.Bool(false),
 					})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{})),
-					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_host", tfjsonpath.New("interface"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("content"), knownvalue.ListExact([]knownvalue.Check{})),
+					statecheck.ExpectKnownValue("opnsense_firewall_alias.test_acc_resource_default", tfjsonpath.New("interface"), knownvalue.StringExact("")),
 				},
 			},
 			// ImportState testing
 			{
-				ResourceName:            "opnsense_firewall_alias.test_acc_resource_host",
+				ResourceName:            "opnsense_firewall_alias.test_acc_resource_default",
 				ImportState:             true,
 				ImportStateId:           "test_acc_alias_host_resource",
 				ImportStateVerify:       true,
@@ -221,7 +221,7 @@ const testAccAliasResourceConfig_host_modified = `
 
 // testAccAliasResourceConfig_dynipv6 defines an alias resource of type `dynipv6host` tests interface).
 const testAccAliasResourceConfig_dynipv6 = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+	resource "opnsense_firewall_alias" "test_acc_resource_dynipv6" {
 		name = "test_acc_alias_dynipv6_resource"
 		type = "dynipv6host"
 		interface = "opt1"
@@ -230,7 +230,7 @@ const testAccAliasResourceConfig_dynipv6 = `
 
 // testAccAliasResourceConfig_dynipv6_modified defines a modified alias resource of type `dynipv6host` (tests interface).
 const testAccAliasResourceConfig_dynipv6_modified = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+	resource "opnsense_firewall_alias" "test_acc_resource_dynipv6" {
 		name = "test_acc_alias_dynipv6_resource"
 		type = "dynipv6host"
 		interface = "lan"
@@ -239,7 +239,7 @@ const testAccAliasResourceConfig_dynipv6_modified = `
 
 // testAccAliasResourceConfig_asn defines an alias resource of type `asn` (tests proto).
 const testAccAliasResourceConfig_asn = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+	resource "opnsense_firewall_alias" "test_acc_resource_asn" {
 		name = "test_acc_alias_asn_resource"
 		type = "asn"
 		proto = {
@@ -251,7 +251,7 @@ const testAccAliasResourceConfig_asn = `
 
 // testAccAliasResourceConfig_asn_modified defines a modified alias resource of type `asn` (tests proto).
 const testAccAliasResourceConfig_asn_modified = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+	resource "opnsense_firewall_alias" "test_acc_resource_asn" {
 		name = "test_acc_alias_asn_resource"
 		type = "asn"
 		proto = {
@@ -263,7 +263,7 @@ const testAccAliasResourceConfig_asn_modified = `
 
 // testAccAliasResourceConfig_default defines an alias resource of type `host` with default values.
 const testAccAliasResourceConfig_default = `
-	resource "opnsense_firewall_alias" "test_acc_resource_host" {
+	resource "opnsense_firewall_alias" "test_acc_resource_default" {
 		name = "test_acc_alias_host_resource"
 		type = "host"
 	}

--- a/internal/opnsense/firewall/alias/api.go
+++ b/internal/opnsense/firewall/alias/api.go
@@ -172,6 +172,7 @@ func aliasToHttpBody(alias alias) aliasHttpBody {
 			Content:     strings.Join(alias.Content, "\n"),
 			Counters:    utils.BoolToInt(alias.Counters),
 			Description: alias.Description,
+			Interface:   alias.Interface,
 		},
 	}
 }
@@ -266,6 +267,14 @@ func getAlias(client *opnsense.Client, uuid string) (*alias, error) {
 		}
 	}
 
+	var aliasInterface string
+	for name, value := range aliasResponse.Alias.AliasInterface {
+		if value.Selected == 1 {
+			aliasInterface = name
+			break
+		}
+	}
+
 	// Sort lists for predictable output
 	sort.Strings(categories)
 	sort.Strings(contents)
@@ -278,7 +287,7 @@ func getAlias(client *opnsense.Client, uuid string) (*alias, error) {
 		Description: aliasResponse.Alias.Description,
 		Type:        aliasType,
 		Proto:       protos,
-		Interface:   aliasResponse.Alias.Description,
+		Interface:   aliasInterface,
 		Content:     contents,
 		Categories:  categories,
 	}, nil

--- a/internal/opnsense/firewall/alias/api.go
+++ b/internal/opnsense/firewall/alias/api.go
@@ -247,13 +247,6 @@ func getAlias(client *opnsense.Client, uuid string) (*alias, error) {
 		}
 	}
 
-	interfaces := make([]string, 0)
-	for name, value := range aliasResponse.Alias.AliasInterface {
-		if value.Selected == 1 && strings.ToLower(value.Value) != "none" {
-			interfaces = append(interfaces, name)
-		}
-	}
-
 	contents := make([]string, 0)
 	for name, value := range aliasResponse.Alias.Content {
 		if value.Selected == 1 && value.Value != "" {
@@ -276,7 +269,6 @@ func getAlias(client *opnsense.Client, uuid string) (*alias, error) {
 	// Sort lists for predictable output
 	sort.Strings(categories)
 	sort.Strings(contents)
-	sort.Strings(interfaces)
 
 	return &alias{
 		Enabled:     aliasResponse.Alias.Enabled == 1,
@@ -286,7 +278,7 @@ func getAlias(client *opnsense.Client, uuid string) (*alias, error) {
 		Description: aliasResponse.Alias.Description,
 		Type:        aliasType,
 		Proto:       protos,
-		Interfaces:  interfaces,
+		Interface:   aliasResponse.Alias.Description,
 		Content:     contents,
 		Categories:  categories,
 	}, nil

--- a/internal/opnsense/firewall/alias/utils.go
+++ b/internal/opnsense/firewall/alias/utils.go
@@ -111,13 +111,13 @@ func createAlias(ctx context.Context, client *opnsense.Client, plan aliasResourc
 
 	tflog.Debug(ctx, "Successfully verified categories", map[string]any{"success": true})
 
-	// Verify interfaces (if type is dynipv6)
+	// Verify interface (if type is dynipv6)
 	if plan.Type.Equal(types.StringValue("dynipv6")) {
 		if plan.Interface.ValueString() == "" {
 			diagnostics.AddAttributeError(path.Root("interface"), "Missing Required Attribute", "The `interface` attribute must be set when `type` is set to `dynipv6`")
 		}
 
-		tflog.Debug(ctx, "Verifying interface", map[string]interface{}{
+		tflog.Debug(ctx, "Verifying interface", map[string]any{
 			"interface": plan.Interface,
 		})
 
@@ -133,7 +133,7 @@ func createAlias(ctx context.Context, client *opnsense.Client, plan aliasResourc
 	}
 
 	// Create alias from plan
-	tflog.Debug(ctx, "Creating alias object from plan", map[string]interface{}{"plan": plan})
+	tflog.Debug(ctx, "Creating alias object from plan", map[string]any{"plan": plan})
 
 	// Compute update frequency
 	var planUpdateFreq updateFreqModel


### PR DESCRIPTION
Dynamic IPV6 alias type's content should only allow a single value instead of multiple values