### PR TITLE
enhancement: migrate list attributes to set attributes

### DIFF
--- a/docs/data-sources/firewall_alias.md
+++ b/docs/data-sources/firewall_alias.md
@@ -34,8 +34,8 @@ data "opnsense_firewall_alias" "data_source_via_name" {
 
 ### Read-Only
 
-- `categories` (List of String) The categories of the alias.
-- `content` (List of String) The content of the alias.
+- `categories` (Set of String) The categories of the alias.
+- `content` (Set of String) The content of the alias.
 - `counters` (Boolean) Whether the statistics of the alias is enabled.
 - `description` (String) The description of the alias.
 - `enabled` (Boolean) Whether the alias is enabled.

--- a/docs/data-sources/firewall_automation_filter.md
+++ b/docs/data-sources/firewall_automation_filter.md
@@ -24,12 +24,12 @@ data "opnsense_firewall_automation_filter" "data_source_via_id" {
 
 ### Required
 
-- `id` (String) Identifier of the firewall automation filter rule.
+- `id` (String) Identifier of the automation filter rule.
 
 ### Read-Only
 
 - `action` (String) Action taken with packets that match the criteria specified. The difference between block and reject is that with reject, a packet (TCP RST or ICMP port unreachable for UDP) is returned to the sender, whereas with block the packet is dropped silently. In either case, the original packet is discarded.
-- `categories` (List of String) The categories of the rule.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) Description to identify this rule.
 - `destination` (String) Destination IP or network.
 - `destination_not` (Boolean) Whether the destination matching should be inverted.
@@ -37,7 +37,7 @@ data "opnsense_firewall_automation_filter" "data_source_via_id" {
 - `direction` (String) Direction of packet matching.
 - `enabled` (Boolean) Whether the rule is enabled.
 - `gateway` (String) Gateway utilized in policy based routing. An empty value uses the system routing table.
-- `interfaces` (List of String) Interfaces this rule applies to.
+- `interfaces` (Set of String) Interfaces this rule applies to.
 - `ip_version` (String) The applicable ip version this for this rule.
 - `log` (Boolean) Whether packets that are handled by this rule should be logged.
 - `protocol` (String) The applicable protocol for this rule.

--- a/docs/data-sources/firewall_automation_source_nat.md
+++ b/docs/data-sources/firewall_automation_source_nat.md
@@ -28,7 +28,7 @@ data "opnsense_firewall_automation_source_nat" "data_source_via_id" {
 
 ### Read-Only
 
-- `categories` (List of String) The categories of the rule.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) Description to identify this rule.
 - `destination` (String) Destination IP or network.
 - `destination_not` (Boolean) Whether the destination matching should be inverted.

--- a/docs/data-sources/firewall_group.md
+++ b/docs/data-sources/firewall_group.md
@@ -35,6 +35,6 @@ data "opnsense_firewall_group" "data_source_via_name" {
 ### Read-Only
 
 - `description` (String) The description of the group.
-- `members` (List of String) Member interfaces of the group.
+- `members` (Set of String) Member interfaces of the group.
 - `no_group` (Boolean) If grouping these members in the interfaces menu section should be prevented.
 - `sequence` (Number) Priority sequence used in sorting the groups.

--- a/docs/data-sources/firewall_nat_nptv6.md
+++ b/docs/data-sources/firewall_nat_nptv6.md
@@ -24,11 +24,11 @@ data "opnsense_firewall_nat_nptv6" "data_source_via_id" {
 
 ### Required
 
-- `id` (String) Identifier of the NPTv6 rule entry.
+- `id` (String) Identifier of the NPTv6 NAT rule.
 
 ### Read-Only
 
-- `categories` (List of String) The categories of the rule.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) The description of the rule.
 - `enabled` (Boolean) Whether the NPTv6 rule entry is enabled.
 - `external_prefix` (String) The external IPv6 prefix. This will replace the prefix of the source address in outbound packets. Leave empty to auto-detect the prefix address using the specified tracking interface instead. The prefix size specified for the internal prefix will also be applied to the external prefix.

--- a/docs/data-sources/firewall_nat_one_to_one.md
+++ b/docs/data-sources/firewall_nat_one_to_one.md
@@ -24,11 +24,11 @@ data "opnsense_firewall_nat_one_to_one" "data_source_via_id" {
 
 ### Required
 
-- `id` (String) Identifier of the one-to-one nat entry.
+- `id` (String) Identifier of the one-to-one NAT rule.
 
 ### Read-Only
 
-- `categories` (List of String) The categories of the rule.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) The description of the rule.
 - `destination` (String) The 1:1 mapping will only be used for connections to or from the specified destination.
 - `destination_not` (Boolean) Whether the destination matching should be inverted.

--- a/docs/data-sources/firewall_shaper_rules.md
+++ b/docs/data-sources/firewall_shaper_rules.md
@@ -31,9 +31,9 @@ data "opnsense_firewall_shaper_rules" "data_source_via_id" {
 - `description` (String) Description to identify this rule.
 - `destination_not` (Boolean) Whether the destination matching should be inverted.
 - `destination_port` (String) Destination port number or well known name.
-- `destinations` (List of String) Destination ips or networks, examples `10.0.0.0/24`, `10.0.0.1`.
+- `destinations` (Set of String) Destination ips or networks, examples `10.0.0.0/24`, `10.0.0.1`.
 - `direction` (String) Direction of packet matching.
-- `dscp` (List of String) Match against one or multiple DSCP values.
+- `dscp` (Set of String) Match against one or multiple DSCP values.
 - `enabled` (Boolean) Whether the traffic shaper rule is enabled.
 - `interface` (String) The interface this rule applies to.
 - `interface2` (String) The secondary interface, matches packets traveling to/from interface (1) to/from interface (2). Can be combined with direction.
@@ -42,5 +42,5 @@ data "opnsense_firewall_shaper_rules" "data_source_via_id" {
 - `sequence` (Number) Order in which the rule will be evaluated (lowest first).
 - `source_not` (Boolean) Whether the source matching should be inverted.
 - `source_port` (String) Source port number or well known name.
-- `sources` (List of String) Source IPs or networks, examples `10.0.0.0/24`, `10.0.0.1`.
+- `sources` (Set of String) Source IPs or networks, examples `10.0.0.0/24`, `10.0.0.1`.
 - `target` (String) Target pipe or queue.

--- a/docs/resources/firewall_alias.md
+++ b/docs/resources/firewall_alias.md
@@ -36,8 +36,8 @@ resource "opnsense_firewall_alias" "resource_example" {
 
 ### Optional
 
-- `categories` (List of String) The categories of the alias. Ensure that the categories are in lexicographical order, else the provider will detect a change on every execution.
-- `content` (List of String) The content of the alias. Ensure that the content are in lexicographical order, else the provider will detect a change on every execution.
+- `categories` (Set of String) The categories of the alias.
+- `content` (Set of String) The content of the alias.
 - `counters` (Boolean) Whether the statistics of the alias is enabled. Defaults to `false`.
 - `description` (String) The description of the alias.
 - `enabled` (Boolean) Whether the alias is enabled. Defaults to `true`.
@@ -48,7 +48,7 @@ resource "opnsense_firewall_alias" "resource_example" {
 ### Read-Only
 
 - `id` (String) Identifier of the alias.
-- `last_updated` (String) DateTime when alias was last updated.
+- `last_updated` (String) DateTime when the alias was last updated.
 
 <a id="nestedatt--proto"></a>
 ### Nested Schema for `proto`

--- a/docs/resources/firewall_automation_filter.md
+++ b/docs/resources/firewall_automation_filter.md
@@ -47,7 +47,7 @@ resource "opnsense_firewall_automation_filter" "test_acc_resource_filter" {
 ### Optional
 
 - `action` (String) Choose what to do with packets that match the criteria specified. The difference between block and reject is that with reject, a packet (TCP RST or ICMP port unreachable for UDP) is returned to the sender, whereas with block the packet is dropped silently. In either case, the original packet is discarded. Must be one of: `pass`, `block`, `reject`. Defaults to `pass`
-- `categories` (List of String) The categories of the rule. Ensure that the categories are in lexicographical order, else the provider will detect a change on every execution.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) Description to identify this rule.
 - `destination` (String) Destination IP or network. Can be a single network/host, alias or predefined network. For interface addresses, add `ip` to the end of the interface name (e.g `opt1ip`). Defaults to `any`
 - `destination_not` (Boolean) Whether the destination matching should be inverted. Defaults to `false`.
@@ -55,7 +55,7 @@ resource "opnsense_firewall_automation_filter" "test_acc_resource_filter" {
 - `direction` (String) Direction of packet matching. Must be one of: `in`, `out`. Defaults to `in`.
 - `enabled` (Boolean) Whether the rule is enabled. Defaults to `true`.
 - `gateway` (String) Choose a gateway to utilize policy based routing. Leave empty to use the system routing table.
-- `interfaces` (List of String) Interfaces this rule applies to. Use the interface identifiers (e.g `lan`, `opt1`) Ensure that the interfaces are in lexicographical order, else the provider will detect a change on every execution.
+- `interfaces` (Set of String) Interfaces this rule applies to. Use the interface identifiers (e.g `lan`, `opt1`).
 - `ip_version` (String) The applicable ip version this for this rule. Must be one of: `ipv4`, `ipv6`. Defaults to `ipv4`.
 - `log` (Boolean) Whether packets that are handled by this rule should be logged. Defaults to `false`.
 - `protocol` (String) The applicable protocol for this rule. Must be one of: `any`, `icmp`, `igmp`, `ggp`, `ipencap`, `st2`, `tcp`, `cbt`, `egp`, `igp`, `bbn-rcc`, `nvp`, `pup`, `argus`, `emcon`, `xnet`, `chaos`, `udp`, `mux`, `dcn`, `hmp`, `prm`, `xns-idp`, `trunk-1`, `trunk-2`, `leaf-1`, `leaf-2`, `rdp`, `irtp`, `iso-tp4`, `netblt`, `mfe-nsp`, `merit-inp`, `dccp`, `3pc`, `idpr`, `xtp`, `ddp`, `idpr-cmtp`, `tp++`, `il`, `ipv6`, `sdrp`, `idrp`, `rsvp`, `gre`, `dsr`, `bna`, `esp`, `ah`, `i-nlsp`, `swipe`, `narp`, `mobile`, `tlsp`, `skip`, `ipv6-icmp`, `cftp`, `sat-expak`, `kryptolan`, `rvd`, `ippc`, `sat-mon`, `visa`, `ipcv`, `cpnx`, `cphb`, `wsn`, `pvp`, `br-sat-mon`, `sun-nd`, `wb-mon`, `wb-expak`, `iso-ip`, `vmtp`, `secure-vmtp`, `vines`, `ttp`, `nsfnet-igp`, `dgp`, `tcf`, `eigrp`, `ospf`, `sprite-rpc`, `larp`, `mtp`, `ax.25`, `ipip`, `micp`, `scc-sp`, `etherip`, `encap`, `gmtp`, `ifmp`, `pnni`, `pim`, `aris`, `scps`, `qnx`, `a/n`, `ipcomp`, `snp`, `compaq-peer`, `ipx-in-ip`, `carp`, `pgm`, `l2tp`, `ddx`, `iatp`, `stp`, `srp`, `uti`, `smp`, `sm`, `ptp`, `isis`, `crtp`, `crudp`, `sps`, `pipe`, `sctp`, `fc`, `rsvp-e2e-ignore`, `udplite`, `mpls-in-ip`, `manet`, `hip`, `shim6`, `wesp`, `rohc`, `pfsync`, `divert`. Defaults to `any`.
@@ -68,7 +68,7 @@ resource "opnsense_firewall_automation_filter" "test_acc_resource_filter" {
 ### Read-Only
 
 - `id` (String) Identifier of the automation filter rule.
-- `last_updated` (String) DateTime when automation filter rule was last updated.
+- `last_updated` (String) DateTime when the automation filter rule was last updated.
 
 ## Import
 

--- a/docs/resources/firewall_automation_source_nat.md
+++ b/docs/resources/firewall_automation_source_nat.md
@@ -47,7 +47,7 @@ resource "opnsense_firewall_automation_filter" "test_acc_resource_filter" {
 
 ### Optional
 
-- `categories` (List of String) The categories of the rule. Ensure that the categories are in lexicographical order, else the provider will detect a change on every execution.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) Description to identify this rule.
 - `destination` (String) Destination IP or network. Can be a single network/host, alias or predefined network. For interface addresses, add `ip` to the end of the interface name (e.g `opt1ip`). Defaults to `any`
 - `destination_not` (Boolean) Whether the destination matching should be inverted. Defaults to `false`.

--- a/docs/resources/firewall_category.md
+++ b/docs/resources/firewall_category.md
@@ -35,7 +35,7 @@ resource "opnsense_firewall_category" "resource_example" {
 ### Read-Only
 
 - `id` (String) Identifier of the category.
-- `last_updated` (String) DateTime when alias was last updated.
+- `last_updated` (String) DateTime when the category was last updated.
 
 ## Import
 

--- a/docs/resources/firewall_group.md
+++ b/docs/resources/firewall_group.md
@@ -32,7 +32,7 @@ resource "opnsense_firewall_group" "resource_example" {
 
 ### Required
 
-- `members` (List of String) Member interfaces of the group. Use the interface identifiers (e.g `lan`, `opt1`) Ensure that the interfaces are in lexicographical order, else the provider will detect a change on every execution.
+- `members` (Set of String) Member interfaces of the group. Use the interface identifiers (e.g `lan`, `opt1`)
 - `name` (String) The name of the group.
 
 ### Optional
@@ -44,7 +44,7 @@ resource "opnsense_firewall_group" "resource_example" {
 ### Read-Only
 
 - `id` (String) Identifier of the group.
-- `last_updated` (String) DateTime when group was last updated.
+- `last_updated` (String) DateTime when the group was last updated.
 
 ## Import
 

--- a/docs/resources/firewall_nat_nptv6.md
+++ b/docs/resources/firewall_nat_nptv6.md
@@ -38,7 +38,7 @@ resource "opnsense_firewall_nat_nptv6" "resource_example" {
 
 ### Optional
 
-- `categories` (List of String) The categories of the rule. Ensure that the categories are in lexicographical order, else the provider will detect a change on every execution.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) The description of the rule.
 - `enabled` (Boolean) Whether the NPTv6 rule entry is enabled. Defaults to `true`.
 - `external_prefix` (String) The external IPv6 prefix. This will replace the prefix of the source address in outbound packets. Leave empty to auto-detect the prefix address using the specified tracking interface instead. The prefix size specified for the internal prefix will also be applied to the external prefix.
@@ -48,8 +48,8 @@ resource "opnsense_firewall_nat_nptv6" "resource_example" {
 
 ### Read-Only
 
-- `id` (String) Identifier of the NPTv6 rule entry.
-- `last_updated` (String) DateTime when NPTv6 rule entry was last updated.
+- `id` (String) Identifier of the NPTv6 NAT rule.
+- `last_updated` (String) DateTime when the NPTv6 NAT rule was last updated.
 
 ## Import
 

--- a/docs/resources/firewall_nat_one_to_one.md
+++ b/docs/resources/firewall_nat_one_to_one.md
@@ -43,7 +43,7 @@ resource "opnsense_firewall_nat_one_to_one" "resource_example" {
 
 ### Optional
 
-- `categories` (List of String) The categories of the rule. Ensure that the categories are in lexicographical order, else the provider will detect a change on every execution.
+- `categories` (Set of String) The categories of the rule.
 - `description` (String) The description of the rule.
 - `destination_not` (Boolean) Whether the destination matching should be inverted. Defaults to `false`.
 - `enabled` (Boolean) Whether the one-to-one nat entry is enabled. Defaults to `true`.
@@ -54,8 +54,8 @@ resource "opnsense_firewall_nat_one_to_one" "resource_example" {
 
 ### Read-Only
 
-- `id` (String) Identifier of the one-to-one nat entry.
-- `last_updated` (String) DateTime when one-to-one nat entry was last updated.
+- `id` (String) Identifier of the one-to-one NAT rule.
+- `last_updated` (String) DateTime when the one-to-one NAT rule entry was last updated.
 
 ## Import
 

--- a/docs/resources/firewall_shaper_pipes.md
+++ b/docs/resources/firewall_shaper_pipes.md
@@ -61,7 +61,7 @@ resource "opnsense_firewall_shaper_pipes" "example_shaper_pipe" {
 ### Read-Only
 
 - `id` (String) Identifier of the traffic shaper pipe.
-- `last_updated` (String) DateTime when traffic shaper pipe was last updated.
+- `last_updated` (String) DateTime when the traffic shaper pipe was last updated.
 
 <a id="nestedatt--bandwidth"></a>
 ### Nested Schema for `bandwidth`

--- a/docs/resources/firewall_shaper_queues.md
+++ b/docs/resources/firewall_shaper_queues.md
@@ -51,7 +51,7 @@ resource "opnsense_firewall_shaper_queues" "example_shaper_queue" {
 ### Read-Only
 
 - `id` (String) Identifier of the traffic shaper queue.
-- `last_updated` (String) DateTime when traffic shaper queue was last updated.
+- `last_updated` (String) DateTime when the traffic shaper queue was last updated.
 
 <a id="nestedatt--codel"></a>
 ### Nested Schema for `codel`

--- a/docs/resources/firewall_shaper_rules.md
+++ b/docs/resources/firewall_shaper_rules.md
@@ -55,9 +55,9 @@ resource "opnsense_firewall_shaper_rules" "example_shaper_rule" {
 - `description` (String) Description to identify this rule.
 - `destination_not` (Boolean) Whether the destination matching should be inverted. Defaults to `false`.
 - `destination_port` (String) Destination port number or well known name (`imap`, `imaps`, `http`, `https`, ...), for ranges use a dash. Defaults to `any`
-- `destinations` (List of String) Destination ips or networks, examples `10.0.0.0/24`, `10.0.0.1`. Defaults to be `any`. Ensure that the destinations are in lexicographical order, else the provider will detect a change on every execution.
+- `destinations` (Set of String) Destination ips or networks, examples `10.0.0.0/24`, `10.0.0.1`. Defaults to be `any`.
 - `direction` (String) Direction of packet matching. Must be one of: `both`, `in`, `out`. Defaults to `both`.
-- `dscp` (List of String) Match against one or multiple DSCP values. Allowed values: `af11`, `af12`, `af13`, `af21`, `af22`, `af23`, `af31`, `af32`, `af33`, `af41`, `af42`, `best effort`, `cs1`, `cs2`, `cs3`, `cs4`, `cs5`, `cs6`, `cs7`, `expedited forwarding`. Ensure that the dscp values are in lexicographical order, else the provider will detect a change on every execution.
+- `dscp` (Set of String) Match against one or multiple DSCP values. Allowed values: `af11`, `af12`, `af13`, `af21`, `af22`, `af23`, `af31`, `af32`, `af33`, `af41`, `af42`, `best effort`, `cs1`, `cs2`, `cs3`, `cs4`, `cs5`, `cs6`, `cs7`, `expedited forwarding`.
 - `enabled` (Boolean) Whether the traffic shaper rule is enabled. Defaults to `true`.
 - `interface2` (String) The secondary interface, matches packets traveling to/from interface (1) to/from interface (2). Can be combined with direction.
 - `max_packet_length` (Number) Specifies the maximum size of packets to match in bytes.
@@ -65,12 +65,12 @@ resource "opnsense_firewall_shaper_rules" "example_shaper_rule" {
 - `sequence` (Number) Order in which the rule will be evaluated (lowest first). Defaults to `1`.
 - `source_not` (Boolean) Whether the source matching should be inverted. Defaults to `false`.
 - `source_port` (String) Source port number or well known name (`imap`, `imaps`, `http`, `https`, ...), for ranges use a dash. Defaults to `any`
-- `sources` (List of String) Source IPs or networks, examples `10.0.0.0/24`, `10.0.0.1`. Defaults to be `any`. Ensure that the sources are in lexicographical order, else the provider will detect a change on every execution.
+- `sources` (Set of String) Source IPs or networks, examples `10.0.0.0/24`, `10.0.0.1`. Defaults to be `any`.
 
 ### Read-Only
 
 - `id` (String) Identifier of the traffic shaper rule.
-- `last_updated` (String) DateTime when traffic shaper rule was last updated.
+- `last_updated` (String) DateTime when the traffic shaper rule was last updated.
 
 ## Import
 

--- a/internal/opnsense/client.go
+++ b/internal/opnsense/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
@@ -35,12 +36,7 @@ func isSupportedHttpMethod(method string) bool {
 		"POST",
 	}
 
-	for _, m := range validMethods {
-		if strings.ToUpper(method) == m {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validMethods, strings.ToUpper(method))
 }
 
 // NewClient creates and initialises a client instance.

--- a/internal/opnsense/firewall/alias/alias_data_source.go
+++ b/internal/opnsense/firewall/alias/alias_data_source.go
@@ -36,17 +36,17 @@ type aliasDataSource struct {
 
 // aliasDataSourceModel describes the data source data model.
 type aliasDataSourceModel struct {
-	Id          types.String   `tfsdk:"id"`
-	Enabled     types.Bool     `tfsdk:"enabled"`
-	Name        types.String   `tfsdk:"name"`
-	Type        types.String   `tfsdk:"type"`
-	Counters    types.Bool     `tfsdk:"counters"`
-	UpdateFreq  types.Object   `tfsdk:"updatefreq"`
-	Description types.String   `tfsdk:"description"`
-	Proto       types.Object   `tfsdk:"proto"`
-	Categories  []types.String `tfsdk:"categories"`
-	Content     []types.String `tfsdk:"content"`
-	Interface   types.String   `tfsdk:"interface"`
+	Id          types.String `tfsdk:"id"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	Name        types.String `tfsdk:"name"`
+	Type        types.String `tfsdk:"type"`
+	Counters    types.Bool   `tfsdk:"counters"`
+	UpdateFreq  types.Object `tfsdk:"updatefreq"`
+	Description types.String `tfsdk:"description"`
+	Proto       types.Object `tfsdk:"proto"`
+	Categories  types.Set    `tfsdk:"categories"`
+	Content     types.Set    `tfsdk:"content"`
+	Interface   types.String `tfsdk:"interface"`
 }
 
 // Metadata returns the data source type name.
@@ -118,12 +118,12 @@ func (d *aliasDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 					},
 				},
 			},
-			"categories": schema.ListAttribute{
+			"categories": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The categories of the alias.",
 			},
-			"content": schema.ListAttribute{
+			"content": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The content of the alias.",
@@ -244,8 +244,14 @@ func (d *aliasDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	resp.Diagnostics.Append(diags...)
 	data.Proto = proto
 
-	data.Categories = utils.StringListGoToTerraform(alias.Categories)
-	data.Content = utils.StringListGoToTerraform(alias.Content)
+	categories, diags := utils.SetGoToTerraform(ctx, alias.Categories)
+	resp.Diagnostics.Append(diags...)
+	data.Categories = categories
+
+	content, diags := utils.SetGoToTerraform(ctx, alias.Content)
+	resp.Diagnostics.Append(diags...)
+	data.Content = content
+
 	data.Interface = types.StringValue(alias.Interface)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/opnsense/firewall/automation/filter/filter_data_source.go
+++ b/internal/opnsense/firewall/automation/filter/filter_data_source.go
@@ -33,25 +33,25 @@ type automationFilterDataSource struct {
 
 // automationFilterDataSourceModel describes the resource data model.
 type automationFilterDataSourceModel struct {
-	Id              types.String   `tfsdk:"id"`
-	Enabled         types.Bool     `tfsdk:"enabled"`
-	Sequence        types.Int32    `tfsdk:"sequence"`
-	Action          types.String   `tfsdk:"action"`
-	Quick           types.Bool     `tfsdk:"quick"`
-	Interfaces      []types.String `tfsdk:"interfaces"`
-	Direction       types.String   `tfsdk:"direction"`
-	IpVersion       types.String   `tfsdk:"ip_version"`
-	Protocol        types.String   `tfsdk:"protocol"`
-	Source          types.String   `tfsdk:"source"`
-	SourceNot       types.Bool     `tfsdk:"source_not"`
-	SourcePort      types.String   `tfsdk:"source_port"`
-	Destination     types.String   `tfsdk:"destination"`
-	DestinationNot  types.Bool     `tfsdk:"destination_not"`
-	DestinationPort types.String   `tfsdk:"destination_port"`
-	Gateway         types.String   `tfsdk:"gateway"`
-	Log             types.Bool     `tfsdk:"log"`
-	Categories      []types.String `tfsdk:"categories"`
-	Description     types.String   `tfsdk:"description"`
+	Id              types.String `tfsdk:"id"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	Sequence        types.Int32  `tfsdk:"sequence"`
+	Action          types.String `tfsdk:"action"`
+	Quick           types.Bool   `tfsdk:"quick"`
+	Interfaces      types.Set    `tfsdk:"interfaces"`
+	Direction       types.String `tfsdk:"direction"`
+	IpVersion       types.String `tfsdk:"ip_version"`
+	Protocol        types.String `tfsdk:"protocol"`
+	Source          types.String `tfsdk:"source"`
+	SourceNot       types.Bool   `tfsdk:"source_not"`
+	SourcePort      types.String `tfsdk:"source_port"`
+	Destination     types.String `tfsdk:"destination"`
+	DestinationNot  types.Bool   `tfsdk:"destination_not"`
+	DestinationPort types.String `tfsdk:"destination_port"`
+	Gateway         types.String `tfsdk:"gateway"`
+	Log             types.Bool   `tfsdk:"log"`
+	Categories      types.Set    `tfsdk:"categories"`
+	Description     types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -84,7 +84,7 @@ func (d *automationFilterDataSource) Schema(ctx context.Context, req datasource.
 				Computed:    true,
 				Description: "If a packet matches a rule specifying quick, then that rule is considered the last matching rule and the specified action is taken. When a rule does not have quick enabled, the last matching rule wins.",
 			},
-			"interfaces": schema.ListAttribute{
+			"interfaces": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Interfaces this rule applies to.",
@@ -133,7 +133,7 @@ func (d *automationFilterDataSource) Schema(ctx context.Context, req datasource.
 				Computed:    true,
 				Description: "Whether packets that are handled by this rule should be logged.",
 			},
-			"categories": schema.ListAttribute{
+			"categories": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The categories of the rule.",
@@ -199,7 +199,11 @@ func (d *automationFilterDataSource) Read(ctx context.Context, req datasource.Re
 	data.Sequence = types.Int32Value(rule.Sequence)
 	data.Action = types.StringValue(rule.Action)
 	data.Quick = types.BoolValue(rule.Quick)
-	data.Interfaces = utils.StringListGoToTerraform(rule.Interfaces)
+
+	interfaces, diags := utils.SetGoToTerraform(ctx, rule.Interfaces)
+	resp.Diagnostics.Append(diags...)
+	data.Interfaces = interfaces
+
 	data.Direction = types.StringValue(rule.Direction)
 	data.IpVersion = types.StringValue(rule.IpVersion)
 	data.Protocol = types.StringValue(rule.Protocol)
@@ -211,7 +215,11 @@ func (d *automationFilterDataSource) Read(ctx context.Context, req datasource.Re
 	data.DestinationPort = types.StringValue(rule.DestinationPort)
 	data.Gateway = types.StringValue(rule.Gateway)
 	data.Log = types.BoolValue(rule.Log)
-	data.Categories = utils.StringListGoToTerraform(rule.Categories)
+
+	categories, diags := utils.SetGoToTerraform(ctx, rule.Categories)
+	resp.Diagnostics.Append(diags...)
+	data.Categories = categories
+
 	data.Description = types.StringValue(rule.Description)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/opnsense/firewall/automation/filter/utils.go
+++ b/internal/opnsense/firewall/automation/filter/utils.go
@@ -25,7 +25,7 @@ type automationFilter struct {
 	Sequence        int32
 	Action          string
 	Quick           bool
-	Interfaces      []string
+	Interfaces      *utils.Set
 	Direction       string
 	IpVersion       string
 	Protocol        string
@@ -37,7 +37,7 @@ type automationFilter struct {
 	DestinationPort string
 	Gateway         string
 	Log             bool
-	Categories      []string
+	Categories      *utils.Set
 	Description     string
 }
 
@@ -232,7 +232,8 @@ func createAutomationFilter(ctx context.Context, client *opnsense.Client, plan a
 	// Verify interfaces
 	tflog.Debug(ctx, "Verifying interfaces", map[string]any{"interfaces": plan.Interfaces})
 
-	interfaces := utils.StringListTerraformToGo(plan.Interfaces)
+	interfaces, diags := utils.SetTerraformToGo(ctx, plan.Interfaces)
+	diagnostics.Append(diags...)
 
 	interfacesExist, err := overview.VerifyInterfaces(client, interfaces)
 	if err != nil {
@@ -262,7 +263,7 @@ func createAutomationFilter(ctx context.Context, client *opnsense.Client, plan a
 	// Verify all categories exist
 	tflog.Debug(ctx, "Verifying categories", map[string]any{"categories": plan.Categories})
 
-	categories := utils.StringListTerraformToGo(plan.Categories)
+	categories, diags := utils.SetTerraformToGo(ctx, plan.Categories)
 
 	categoryUuids, err := category.GetCategoryUuids(client, categories)
 	if err != nil {

--- a/internal/opnsense/firewall/automation/sourcenat/sourcenat_data_source.go
+++ b/internal/opnsense/firewall/automation/sourcenat/sourcenat_data_source.go
@@ -33,24 +33,24 @@ type automationSourceNatDataSource struct {
 
 // automationSourceNatDataSourceModel describes the resource data model.
 type automationSourceNatDataSourceModel struct {
-	Id              types.String   `tfsdk:"id"`
-	Enabled         types.Bool     `tfsdk:"enabled"`
-	NoNat           types.Bool     `tfsdk:"no_nat"`
-	Sequence        types.Int32    `tfsdk:"sequence"`
-	Interface       types.String   `tfsdk:"interface"`
-	IpVersion       types.String   `tfsdk:"ip_version"`
-	Protocol        types.String   `tfsdk:"protocol"`
-	Source          types.String   `tfsdk:"source"`
-	SourceNot       types.Bool     `tfsdk:"source_not"`
-	SourcePort      types.String   `tfsdk:"source_port"`
-	Destination     types.String   `tfsdk:"destination"`
-	DestinationNot  types.Bool     `tfsdk:"destination_not"`
-	DestinationPort types.String   `tfsdk:"destination_port"`
-	Target          types.String   `tfsdk:"target"`
-	TargetPort      types.String   `tfsdk:"target_port"`
-	Log             types.Bool     `tfsdk:"log"`
-	Categories      []types.String `tfsdk:"categories"`
-	Description     types.String   `tfsdk:"description"`
+	Id              types.String `tfsdk:"id"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	NoNat           types.Bool   `tfsdk:"no_nat"`
+	Sequence        types.Int32  `tfsdk:"sequence"`
+	Interface       types.String `tfsdk:"interface"`
+	IpVersion       types.String `tfsdk:"ip_version"`
+	Protocol        types.String `tfsdk:"protocol"`
+	Source          types.String `tfsdk:"source"`
+	SourceNot       types.Bool   `tfsdk:"source_not"`
+	SourcePort      types.String `tfsdk:"source_port"`
+	Destination     types.String `tfsdk:"destination"`
+	DestinationNot  types.Bool   `tfsdk:"destination_not"`
+	DestinationPort types.String `tfsdk:"destination_port"`
+	Target          types.String `tfsdk:"target"`
+	TargetPort      types.String `tfsdk:"target_port"`
+	Log             types.Bool   `tfsdk:"log"`
+	Categories      types.Set    `tfsdk:"categories"`
+	Description     types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -127,7 +127,7 @@ func (d *automationSourceNatDataSource) Schema(ctx context.Context, req datasour
 				Computed:    true,
 				Description: "Whether packets that are handled by this rule should be logged.",
 			},
-			"categories": schema.ListAttribute{
+			"categories": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The categories of the rule.",
@@ -204,7 +204,11 @@ func (d *automationSourceNatDataSource) Read(ctx context.Context, req datasource
 	data.Target = types.StringValue(rule.Target)
 	data.TargetPort = types.StringValue(rule.TargetPort)
 	data.Log = types.BoolValue(rule.Log)
-	data.Categories = utils.StringListGoToTerraform(rule.Categories)
+
+	categories, diags := utils.SetGoToTerraform(ctx, rule.Categories)
+	resp.Diagnostics.Append(diags...)
+	data.Categories = categories
+
 	data.Description = types.StringValue(rule.Description)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/opnsense/firewall/automation/sourcenat/utils.go
+++ b/internal/opnsense/firewall/automation/sourcenat/utils.go
@@ -35,7 +35,7 @@ type automationSourceNat struct {
 	Target          string
 	TargetPort      string
 	Log             bool
-	Categories      []string
+	Categories      *utils.Set
 	Description     string
 }
 
@@ -228,7 +228,8 @@ func createAutomationSourceNat(ctx context.Context, client *opnsense.Client, pla
 	// Verify all categories exist
 	tflog.Debug(ctx, "Verifying categories", map[string]any{"categories": plan.Categories})
 
-	categories := utils.StringListTerraformToGo(plan.Categories)
+	categories, diags := utils.SetTerraformToGo(ctx, plan.Categories)
+	diagnostics.Append(diags...)
 
 	categoryUuids, err := category.GetCategoryUuids(client, categories)
 	if err != nil {

--- a/internal/opnsense/firewall/category/utils.go
+++ b/internal/opnsense/firewall/category/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"terraform-provider-opnsense/internal/opnsense"
+	"terraform-provider-opnsense/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -39,9 +40,9 @@ func createCategory(ctx context.Context, plan categoryResourceModel) category {
 }
 
 // getCategoryUuids checks if the specified categories exist on the OPNsense firewall and returns their respective uuids.
-func GetCategoryUuids(client *opnsense.Client, categoriesList []string) ([]string, error) {
-	var categoryUuids []string
-	for _, cat := range categoriesList {
+func GetCategoryUuids(client *opnsense.Client, categoriesList *utils.Set) (*utils.Set, error) {
+	categoryUuids := utils.NewSet()
+	for _, cat := range categoriesList.Elements() {
 		uuid, err := searchCategory(client, cat)
 		if err != nil {
 			return nil, fmt.Errorf("%s", err)
@@ -51,7 +52,7 @@ func GetCategoryUuids(client *opnsense.Client, categoriesList []string) ([]strin
 			return nil, fmt.Errorf("Get category UUID error: category `%s` does not exist", cat)
 		}
 
-		categoryUuids = append(categoryUuids, uuid)
+		categoryUuids.Add(uuid)
 	}
 	return categoryUuids, nil
 }

--- a/internal/opnsense/firewall/group/api.go
+++ b/internal/opnsense/firewall/group/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 
 	"terraform-provider-opnsense/internal/opnsense"
@@ -82,7 +81,7 @@ func groupToHttpBody(group group) groupHttpBody {
 	return groupHttpBody{
 		Group: groupRequest{
 			IfName:      group.Name,
-			Members:     strings.Join(group.Members, ","),
+			Members:     strings.Join(group.Members.Elements(), ","),
 			NoGroup:     utils.BoolToInt(group.NoGroup),
 			Sequence:    group.Sequence,
 			Description: group.Description,
@@ -154,15 +153,12 @@ func getGroup(client *opnsense.Client, uuid string) (*group, error) {
 	}
 
 	// Extract values from response
-	var members []string
+	members := utils.NewSet()
 	for name, value := range resp.Group.Members {
 		if value.Selected == 1 {
-			members = append(members, name)
+			members.Add(name)
 		}
 	}
-
-	// Sort lists for predictable output
-	sort.Strings(members)
 
 	return &group{
 		Name:        resp.Group.IfName,

--- a/internal/opnsense/firewall/group/group_data_source.go
+++ b/internal/opnsense/firewall/group/group_data_source.go
@@ -35,12 +35,12 @@ type groupDataSource struct {
 
 // groupDataSourceModel describes the data source data model.
 type groupDataSourceModel struct {
-	Id          types.String   `tfsdk:"id"`
-	Name        types.String   `tfsdk:"name"`
-	Members     []types.String `tfsdk:"members"`
-	NoGroup     types.Bool     `tfsdk:"no_group"`
-	Sequence    types.Int32    `tfsdk:"sequence"`
-	Description types.String   `tfsdk:"description"`
+	Id          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Members     types.Set    `tfsdk:"members"`
+	NoGroup     types.Bool   `tfsdk:"no_group"`
+	Sequence    types.Int32  `tfsdk:"sequence"`
+	Description types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -68,7 +68,7 @@ func (d *groupDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 					}...),
 				},
 			},
-			"members": schema.ListAttribute{
+			"members": schema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "Member interfaces of the group.",
@@ -154,7 +154,11 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	tflog.Debug(ctx, fmt.Sprintf("Saving %s information to state", resourceName), map[string]any{fmt.Sprintf("%s", resourceName): data})
 
 	data.Name = types.StringValue(group.Name)
-	data.Members = utils.StringListGoToTerraform(group.Members)
+
+	members, diags := utils.SetGoToTerraform(ctx, group.Members)
+	resp.Diagnostics.Append(diags...)
+	data.Members = members
+
 	data.NoGroup = types.BoolValue(group.NoGroup)
 	data.Sequence = types.Int32Value(group.Sequence)
 	data.Description = types.StringValue(group.Description)

--- a/internal/opnsense/firewall/group/utils.go
+++ b/internal/opnsense/firewall/group/utils.go
@@ -20,7 +20,7 @@ const (
 
 type group struct {
 	Name        string
-	Members     []string
+	Members     *utils.Set
 	NoGroup     bool
 	Sequence    int32
 	Description string
@@ -37,7 +37,8 @@ func createGroup(ctx context.Context, client *opnsense.Client, plan groupResourc
 		"interfaces": plan.Members,
 	})
 
-	interfaces := utils.StringListTerraformToGo(plan.Members)
+	interfaces, diags := utils.SetTerraformToGo(ctx, plan.Members)
+	diagnostics.Append(diags...)
 
 	interfacesExist, err := overview.VerifyInterfaces(client, interfaces)
 	if err != nil {

--- a/internal/opnsense/firewall/nat/nptv6/nptv6_data_source.go
+++ b/internal/opnsense/firewall/nat/nptv6/nptv6_data_source.go
@@ -32,16 +32,16 @@ type natNptv6DataSource struct {
 
 // natNptv6DataSourceModel describes the resource data model.
 type natNptv6DataSourceModel struct {
-	Id             types.String   `tfsdk:"id"`
-	Enabled        types.Bool     `tfsdk:"enabled"`
-	Log            types.Bool     `tfsdk:"log"`
-	Sequence       types.Int32    `tfsdk:"sequence"`
-	Interface      types.String   `tfsdk:"interface"`
-	InternalPrefix types.String   `tfsdk:"internal_prefix"`
-	ExternalPrefix types.String   `tfsdk:"external_prefix"`
-	TrackInterface types.String   `tfsdk:"track_interface"`
-	Categories     []types.String `tfsdk:"categories"`
-	Description    types.String   `tfsdk:"description"`
+	Id             types.String `tfsdk:"id"`
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	Log            types.Bool   `tfsdk:"log"`
+	Sequence       types.Int32  `tfsdk:"sequence"`
+	Interface      types.String `tfsdk:"interface"`
+	InternalPrefix types.String `tfsdk:"internal_prefix"`
+	ExternalPrefix types.String `tfsdk:"external_prefix"`
+	TrackInterface types.String `tfsdk:"track_interface"`
+	Categories     types.Set    `tfsdk:"categories"`
+	Description    types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -87,7 +87,7 @@ func (d *natNptv6DataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				Computed:    true,
 				Description: "Use prefix defined on the selected interface instead of the interface this rule applies to when target prefix is not provided.",
 			},
-			"categories": schema.ListAttribute{
+			"categories": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The categories of the rule.",
@@ -156,7 +156,10 @@ func (d *natNptv6DataSource) Read(ctx context.Context, req datasource.ReadReques
 	data.ExternalPrefix = types.StringValue(rule.ExternalPrefix)
 	data.TrackInterface = types.StringValue(rule.TrackInterface)
 	data.Description = types.StringValue(rule.Description)
-	data.Categories = utils.StringListGoToTerraform(rule.Categories)
+
+	categories, diags := utils.SetGoToTerraform(ctx, rule.Categories)
+	resp.Diagnostics.Append(diags...)
+	data.Categories = categories
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/opnsense/firewall/nat/onetoone/one_to_one_data_source.go
+++ b/internal/opnsense/firewall/nat/onetoone/one_to_one_data_source.go
@@ -32,20 +32,20 @@ type oneToOneNatDataSource struct {
 
 // oneToOneNatDataSourceModel describes the data source data model.
 type oneToOneNatDataSourceModel struct {
-	Id             types.String   `tfsdk:"id"`
-	Enabled        types.Bool     `tfsdk:"enabled"`
-	Log            types.Bool     `tfsdk:"log"`
-	Sequence       types.Int32    `tfsdk:"sequence"`
-	Interface      types.String   `tfsdk:"interface"`
-	Type           types.String   `tfsdk:"type"`
-	Source         types.String   `tfsdk:"source"`
-	SourceNot      types.Bool     `tfsdk:"source_not"`
-	Destination    types.String   `tfsdk:"destination"`
-	DestinationNot types.Bool     `tfsdk:"destination_not"`
-	External       types.String   `tfsdk:"external"`
-	NatReflection  types.String   `tfsdk:"nat_reflection"`
-	Categories     []types.String `tfsdk:"categories"`
-	Description    types.String   `tfsdk:"description"`
+	Id             types.String `tfsdk:"id"`
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	Log            types.Bool   `tfsdk:"log"`
+	Sequence       types.Int32  `tfsdk:"sequence"`
+	Interface      types.String `tfsdk:"interface"`
+	Type           types.String `tfsdk:"type"`
+	Source         types.String `tfsdk:"source"`
+	SourceNot      types.Bool   `tfsdk:"source_not"`
+	Destination    types.String `tfsdk:"destination"`
+	DestinationNot types.Bool   `tfsdk:"destination_not"`
+	External       types.String `tfsdk:"external"`
+	NatReflection  types.String `tfsdk:"nat_reflection"`
+	Categories     types.Set    `tfsdk:"categories"`
+	Description    types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -107,7 +107,7 @@ func (d *oneToOneNatDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:            true,
 				MarkdownDescription: "Whether nat reflection should be enabled.",
 			},
-			"categories": schema.ListAttribute{
+			"categories": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "The categories of the rule.",
@@ -180,7 +180,10 @@ func (d *oneToOneNatDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.External = types.StringValue(rule.External)
 	data.NatReflection = types.StringValue(rule.NatRefection)
 	data.Description = types.StringValue(rule.Description)
-	data.Categories = utils.StringListGoToTerraform(rule.Categories)
+
+	categories, diags := utils.SetGoToTerraform(ctx, rule.Categories)
+	resp.Diagnostics.Append(diags...)
+	data.Categories = categories
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/opnsense/firewall/shaper/rules/rules_data_source.go
+++ b/internal/opnsense/firewall/shaper/rules/rules_data_source.go
@@ -33,23 +33,23 @@ type shaperRulesDataSource struct {
 
 // shaperRulesDataSourceModel describes the resource data model.
 type shaperRulesDataSourceModel struct {
-	Id              types.String   `tfsdk:"id"`
-	Enabled         types.Bool     `tfsdk:"enabled"`
-	Sequence        types.Int32    `tfsdk:"sequence"`
-	Interface       types.String   `tfsdk:"interface"`
-	Interface2      types.String   `tfsdk:"interface2"`
-	Protocol        types.String   `tfsdk:"protocol"`
-	MaxPacketLength types.Int32    `tfsdk:"max_packet_length"`
-	Sources         []types.String `tfsdk:"sources"`
-	SourceNot       types.Bool     `tfsdk:"source_not"`
-	SourcePort      types.String   `tfsdk:"source_port"`
-	Destinations    []types.String `tfsdk:"destinations"`
-	DestinationNot  types.Bool     `tfsdk:"destination_not"`
-	DestinationPort types.String   `tfsdk:"destination_port"`
-	Dscp            []types.String `tfsdk:"dscp"`
-	Direction       types.String   `tfsdk:"direction"`
-	Target          types.String   `tfsdk:"target"`
-	Description     types.String   `tfsdk:"description"`
+	Id              types.String `tfsdk:"id"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	Sequence        types.Int32  `tfsdk:"sequence"`
+	Interface       types.String `tfsdk:"interface"`
+	Interface2      types.String `tfsdk:"interface2"`
+	Protocol        types.String `tfsdk:"protocol"`
+	MaxPacketLength types.Int32  `tfsdk:"max_packet_length"`
+	Sources         types.Set    `tfsdk:"sources"`
+	SourceNot       types.Bool   `tfsdk:"source_not"`
+	SourcePort      types.String `tfsdk:"source_port"`
+	Destinations    types.Set    `tfsdk:"destinations"`
+	DestinationNot  types.Bool   `tfsdk:"destination_not"`
+	DestinationPort types.String `tfsdk:"destination_port"`
+	Dscp            types.Set    `tfsdk:"dscp"`
+	Direction       types.String `tfsdk:"direction"`
+	Target          types.String `tfsdk:"target"`
+	Description     types.String `tfsdk:"description"`
 }
 
 // Metadata returns the data source type name.
@@ -90,7 +90,7 @@ func (d *shaperRulesDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:    true,
 				Description: "Specifies the maximum size of packets to match in bytes. Negative values are treated as default (i.e empty)",
 			},
-			"sources": schema.ListAttribute{
+			"sources": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Source IPs or networks, examples `10.0.0.0/24`, `10.0.0.1`.",
@@ -103,7 +103,7 @@ func (d *shaperRulesDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:    true,
 				Description: "Source port number or well known name.",
 			},
-			"destinations": schema.ListAttribute{
+			"destinations": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Destination ips or networks, examples `10.0.0.0/24`, `10.0.0.1`.",
@@ -116,7 +116,7 @@ func (d *shaperRulesDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:    true,
 				Description: "Destination port number or well known name.",
 			},
-			"dscp": schema.ListAttribute{
+			"dscp": schema.SetAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Match against one or multiple DSCP values.",
@@ -192,13 +192,25 @@ func (d *shaperRulesDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.Interface2 = types.StringValue(rule.Interface2)
 	data.Protocol = types.StringValue(rule.Protocol)
 	data.MaxPacketLength = types.Int32Value(rule.MaxPacketLength)
-	data.Sources = utils.StringListGoToTerraform(rule.Sources)
+
+	sources, diags := utils.SetGoToTerraform(ctx, rule.Sources)
+	resp.Diagnostics.Append(diags...)
+	data.Sources = sources
+
 	data.SourceNot = types.BoolValue(rule.SourceNot)
 	data.SourcePort = types.StringValue(rule.SourcePort)
-	data.Destinations = utils.StringListGoToTerraform(rule.Destinations)
+
+	destinations, diags := utils.SetGoToTerraform(ctx, rule.Destinations)
+	resp.Diagnostics.Append(diags...)
+	data.Destinations = destinations
+
 	data.DestinationNot = types.BoolValue(rule.DestinationNot)
 	data.DestinationPort = types.StringValue(rule.DestinationPort)
-	data.Dscp = utils.StringListGoToTerraform(rule.Dscp)
+
+	dscp, diags := utils.SetGoToTerraform(ctx, rule.Dscp)
+	resp.Diagnostics.Append(diags...)
+	data.Dscp = dscp
+
 	data.Direction = types.StringValue(rule.Direction)
 	data.Target = types.StringValue(rule.Target)
 	data.Description = types.StringValue(rule.Description)

--- a/internal/opnsense/interfaces/overview/utils.go
+++ b/internal/opnsense/interfaces/overview/utils.go
@@ -3,6 +3,7 @@ package overview
 import (
 	"fmt"
 	"terraform-provider-opnsense/internal/opnsense"
+	"terraform-provider-opnsense/internal/utils"
 )
 
 const (
@@ -12,8 +13,8 @@ const (
 )
 
 // VerifyInterfaces checks if the specified list of interfaces exist on the OPNsense firewall.
-func VerifyInterfaces(client *opnsense.Client, interfacesList []string) (bool, error) {
-	for _, iface := range interfacesList {
+func VerifyInterfaces(client *opnsense.Client, interfacesList *utils.Set) (bool, error) {
+	for _, iface := range interfacesList.Elements() {
 		ifaceExists, err := VerifyInterface(client, iface)
 		if err != nil {
 			return false, fmt.Errorf("%s", err)


### PR DESCRIPTION
Set attributes are unordered, unique collection of elements which was how list attributes are previously used.

Migrating to sets allows for cleaner code with re-implementing checks and sorting.

Removes need for users to specify elements in lexicographical ordering. 